### PR TITLE
fix #2 progress range input frozen after user input and playing track

### DIFF
--- a/src/audio-player.ts
+++ b/src/audio-player.ts
@@ -151,6 +151,9 @@ export class AudioPlayer extends LitElement {
       this._draw(canvasCtx, width, height, bufferLength);
     });
     this._pos = this._audio.currentTime;
+    if (this._posControl) {
+      this._posControl.value = `${this._pos}`;
+    }
     canvasCtx.fillStyle = 'rgb(200 200 200)';
     canvasCtx.fillRect(0, 0, width, height);
     canvasCtx.lineWidth = 3;


### PR DESCRIPTION
fixes #2 

Some sort of fight between attributes and properties going out of sync

see https://jakearchibald.com/2024/attributes-vs-properties/ not sure why this isn't handled by lit but there you go.